### PR TITLE
Add debug context to backend

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,7 +7,7 @@
     "test": "yarn test:types && yarn test:lint",
     "test:lint": "eslint \"./src/**/*.{js,ts,tsx}\" --quiet --fix",
     "test:types": "tsc --noEmit",
-    "start": "wrangler dev",
+    "start": "ALLOW_DEBUG=true wrangler dev --env=staging",
     "build": "wrangler build"
   },
   "author": "Lauchlan Irwin <lauchlan.irwin@gmail.com>",

--- a/packages/backend/src/handlers/apollo.ts
+++ b/packages/backend/src/handlers/apollo.ts
@@ -2,7 +2,7 @@ import {ApolloServer, Config} from 'apollo-server-cloudflare';
 import {graphqlCloudflare} from 'apollo-server-cloudflare/dist/cloudflareApollo';
 
 import KVCache from '../cache';
-import {GqlHandlerOptions} from './handler.types';
+import {GqlHandlerOptions} from '../types/handler';
 import {typeDefs, resolvers} from '../schema';
 
 const dataSources = () => ({});

--- a/packages/backend/src/handlers/apollo.ts
+++ b/packages/backend/src/handlers/apollo.ts
@@ -1,24 +1,31 @@
-import {ApolloServer, Config} from 'apollo-server-cloudflare';
+import {ApolloServer, Config as Config} from 'apollo-server-cloudflare';
 import {graphqlCloudflare} from 'apollo-server-cloudflare/dist/cloudflareApollo';
-
+import {Context} from '../types/context';
 import KVCache from '../cache';
 import {GqlHandlerOptions} from '../types/handler';
 import {typeDefs, resolvers} from '../schema';
+import {isDebugRequest} from '..';
 
 const dataSources = () => ({});
 
-const createServer = (graphQLOptions: GqlHandlerOptions) =>
-    new ApolloServer({
+const createServer = (graphQLOptions: GqlHandlerOptions, debug: boolean) => {
+    const context: Context = {
+        DEBUG: debug,
+    };
+
+    return new ApolloServer({
         typeDefs,
         resolvers,
         introspection: true,
-        // @ts-ignore
         dataSources,
         ...(graphQLOptions.kvCache ? {cache: new KVCache()} : {}),
+        context,
     } as Config);
+};
 
 export default (request: Request, graphQLOptions: GqlHandlerOptions): Response => {
-    const server = createServer(graphQLOptions);
+    const debug = graphQLOptions.allowDebug && isDebugRequest(request);
+    const server = createServer(graphQLOptions, debug);
 
     // @ts-ignore
     return graphqlCloudflare(() => server.createGraphQLServerOptions(request))(request);

--- a/packages/backend/src/handlers/apollo.ts
+++ b/packages/backend/src/handlers/apollo.ts
@@ -1,4 +1,4 @@
-import {ApolloServer, Config as Config} from 'apollo-server-cloudflare';
+import {ApolloServer, Config} from 'apollo-server-cloudflare';
 import {graphqlCloudflare} from 'apollo-server-cloudflare/dist/cloudflareApollo';
 import {Context} from '../types/context';
 import KVCache from '../cache';

--- a/packages/backend/src/handlers/playground.ts
+++ b/packages/backend/src/handlers/playground.ts
@@ -1,4 +1,4 @@
-import {GqlHandlerOptions} from './handler.types';
+import {GqlHandlerOptions} from '../types/handler';
 
 const html = (baseEndpoint: string) => `
 <!DOCTYPE html>

--- a/packages/backend/src/helpers/github.ts
+++ b/packages/backend/src/helpers/github.ts
@@ -8,7 +8,7 @@ export async function getGithubStats(username: string = DEFAULT_USERNAME): Promi
     const response = await fetch(`https://github.com/${username}`);
 
     if (response.status !== 200) {
-        return;
+        throw new Error(`Github failed to respond: ${response.statusText} (${response.status})`);
     }
 
     const html = await response.text();

--- a/packages/backend/src/schema/github.ts
+++ b/packages/backend/src/schema/github.ts
@@ -1,5 +1,6 @@
 import {gql} from 'apollo-server-cloudflare';
 import {getGithubStats} from '../helpers/github';
+import {Context} from '../types/context';
 import {GithubStats} from '../types/github';
 
 const typeDefs = gql`
@@ -22,8 +23,13 @@ const typeDefs = gql`
 
 const resolvers = {
     Query: {
-        githubStats: async (): Promise<GithubStats> => {
-            return getGithubStats();
+        githubStats: async (_, __, {DEBUG}: Context): Promise<GithubStats> => {
+            try {
+                return await getGithubStats();
+            } catch (ex) {
+                if (DEBUG) throw ex;
+                else throw new Error('Failed to get github information');
+            }
         },
     },
 };

--- a/packages/backend/src/types/context.ts
+++ b/packages/backend/src/types/context.ts
@@ -1,0 +1,3 @@
+export interface Context {
+    DEBUG: boolean;
+}

--- a/packages/backend/src/types/handler.ts
+++ b/packages/backend/src/types/handler.ts
@@ -2,7 +2,7 @@ export interface GqlHandlerOptions {
     baseEndpoint: string;
     playgroundEndpoint: string;
     forwardUnmatchedRequestsToOrigin: boolean;
-    debug: boolean;
+    allowDebug: boolean;
     cors: boolean | object; // TODO: type this
     kvCache: boolean;
 }

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["ESNext", "WebWorker"],
     "strict": true,
     "preserveConstEnums": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
   },
   "include": [
     "./src/*.ts",


### PR DESCRIPTION
Enable getting unfiltered exceptions from resolvers by providing a DEBUG context flag that can be used to determine how errors are handled