### PR TITLE
Modify release update rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,11 @@ jobs:
       - name: Create Release
         run: yarn lerna version --conventional-commits --yes
 
-      - name: Publish Release
+      - name: Publish release to main branch
         run: git push --follow-tags origin main
+
+      - name: Publish release to staging branch
+        run: git push --follow-tags origin staging
 
       - name: Build Frontend
         run: yarn --cwd ./packages/frontend build


### PR DESCRIPTION
Previously, the release was only updating main, but to make sure that pushes to staging are going to be based off of the latest `main` branch, I have added a run in the release action to also push back to `staging` as well as `main`